### PR TITLE
Hotfix | Upgrade boto3 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:2
+FROM python:2.7-jessie
 WORKDIR /usr/src/app
 VOLUME /data
 
-RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit }' /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list && \
-    apt-get update && \
+RUN echo "deb [check-valid-until=no] http://cdn-fastly.deb.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+RUN apt-get -o Acquire::Check-Valid-Until=false update && \
     apt-get -y upgrade && \
     apt-get -y autoremove && \
     apt-get install -y --no-install-recommends \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 envtpl==0.4.1
-boto3
+boto3==1.9.129
 dateutils==0.6.6
 numpy==1.11.0
 pyremotecv==0.5.0


### PR DESCRIPTION
There appears to be a bug in boto where invalid credentials are being cached. This happens relatively frequently. There is a bug fix available (`https://github.com/boto/botocore/pull/1569`) in more recent boto3 versions that might correct this bug. This PR pins the latest version of boto3 that includes this fix. The PR also modifies the Dockerfile to fix issues building a jessie-based container (jessie backports is no longer updated, so apt, by default, ignores that repo)